### PR TITLE
feat: servicio e implementacion de traduccion del paginador de angular material 

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,9 +26,9 @@ export class AppComponent implements OnInit {
     let lang = getCookie('lang') || 'es';
     this.whatLang$.subscribe((x:any) => {
       lang = x['detail']['answer'];
-      this.translate.setDefaultLang(lang)
+      this.translate.use(lang)
     });
-    this.translate.setDefaultLang(lang);
+    this.translate.use(lang);
   }
 }
  

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,7 +29,7 @@ import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatIconModule} from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
-import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';
 import {MatNativeDateModule} from '@angular/material/core';
 import { ListCalendarioAcademicoComponent } from './component/list-calendario-academico/list-calendario-academico.component';
 import { AsignarCalendarioProyectoComponent } from './component/asignar-calendario-proyecto/asignar-calendario-proyecto.component';
@@ -52,6 +52,7 @@ import {MatButtonModule} from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatMenuModule } from '@angular/material/menu'
+import { CustomPaginatorIntl } from './services/CustomPaginatorIntl.service';
 
 
 export function createTranslateLoader(http: HttpClient) {
@@ -127,7 +128,8 @@ export function createTranslateLoader(http: HttpClient) {
     ParametrosService,
     EventoService,
     PopUpManager,
-    { provide: HTTP_INTERCEPTORS, useClass: SpinnerUtilInterceptor, multi: true }
+    { provide: HTTP_INTERCEPTORS, useClass: SpinnerUtilInterceptor, multi: true },
+    { provide: MatPaginatorIntl, useClass: CustomPaginatorIntl }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/services/CustomPaginatorIntl.service.ts
+++ b/src/app/services/CustomPaginatorIntl.service.ts
@@ -1,0 +1,43 @@
+import { MatPaginatorIntl } from '@angular/material/paginator';
+import { Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Injectable()
+export class CustomPaginatorIntl extends MatPaginatorIntl {
+  constructor(private translate: TranslateService) {
+    super();
+    this.getAndInitTranslations();
+    this.translate.onLangChange.subscribe(() => {
+      this.getAndInitTranslations();
+    });
+  }
+
+  getAndInitTranslations() {
+    this.translate.get([
+      'GLOBAL.items_per_page',
+      'GLOBAL.next_page',
+      'GLOBAL.previous_page',
+      'GLOBAL.first_page',
+      'GLOBAL.last_page',
+      'GLOBAL.of'
+    ]).subscribe(translations => {
+      this.itemsPerPageLabel = translations['GLOBAL.items_per_page'];
+      this.nextPageLabel = translations['GLOBAL.next_page'];
+      this.previousPageLabel = translations['GLOBAL.previous_page'];
+      this.firstPageLabel = translations['GLOBAL.first_page'];
+      this.lastPageLabel = translations['GLOBAL.last_page'];
+      this.changes.next();
+    });
+  }
+
+  override getRangeLabel = (page: number, pageSize: number, length: number): string => {
+    if (length === 0 || pageSize === 0) {
+      return `0 ${this.translate.instant('GLOBAL.of')} ${length}`;
+    }
+    const startIndex = page * pageSize;
+    const endIndex = startIndex < length
+      ? Math.min(startIndex + pageSize, length)
+      : startIndex + pageSize;
+    return `${startIndex + 1} - ${endIndex} ${this.translate.instant('GLOBAL.of')} ${length}`;
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -579,7 +579,13 @@
         "direccion_entidad": "Entity Address",
         "placeholder_direccion_entidad": "E.g.: Cra 8 # 40-78 Piso 1",
         "item": "Item",
-        "evaluar": "Evaluate"
+        "evaluar": "Evaluate",
+        "items_per_page": "Items per page",
+        "next_page": "Next page",
+        "previous_page": "Previous page",
+        "first_page": "First page",
+        "last_page": "Last page",
+        "of": "of"
     },
     "ERROR": {
         "general": "The request could not be satisfied",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -615,7 +615,13 @@
         "direccion_entidad": "Dirección de la entidad",
         "placeholder_direccion_entidad": "Ej: Cra 8 # 40-78 Piso 1",
         "item": "Ítem",
-        "evaluar": "Evaluar"
+        "evaluar": "Evaluar",
+        "items_per_page": "Elementos por página",
+        "next_page": "Página siguiente",
+        "previous_page": "Página anterior",
+        "first_page": "Primera página",
+        "last_page": "Última página",
+        "of": "de"
     },
     "ERROR": {
         "general": "La solicitud no pudo ser cumplida",


### PR DESCRIPTION
- Se implementa un servicio para traducir el paginador de angular material, debido a que este componente no permite de manera directa el cambio de idioma.
- Esta integracion funciona con la implementacion general del sistema.
- Ejemplo de implementacion --> [CLICK AQUI!!](https://github.com/udistrital/sga_cliente_calendario_academico_mf/commit/9d2a517f5a4bc80d301fe49902bd26ce5f8bd5b8)
![n1](https://github.com/user-attachments/assets/531aa3af-a640-48ac-80d0-5b05567530b1)
---
udistrital/sga_documentacion#415